### PR TITLE
Record message in mongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Simple messaging microservice with Kafka and Rust
+# Simple messaging service with Kafka, Mongodb written with Rust
 
 To launch the stack, run:
 
@@ -6,13 +6,24 @@ To launch the stack, run:
 docker-compose up -d 
 ```
 
-Then create a topic:
+Then create a kafka topic:
 
 ```bash
 docker exec -it first-course-kafka-1 /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --create --topic first-course
 ```
+Create the mongo database and collection:
 
-Then run the producer:
+```bash
+docker exec -it first-course-mongodb-1 mongosh
+```
+
+Then in the MongoDB shell, run these commands:
+```mongosh
+use beep
+db.createCollection("messages")
+```
+
+Then run the kafka producer:
 
 ```bash
 docker exec --workdir /opt/kafka/bin/ -it first-course-kafka-1 sh ./kafka-console-producer.sh --bootstrap-server localhost:9092 --topic first-course
@@ -24,6 +35,11 @@ Then cargo run in another terminal to run the service:
 cargo run
 ```
 
+To receive messages throught sse you can simply: 
+
+```bash
+curl -N http://localhost:8080/sse
+```
 
 ## Description
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,13 @@ services:
     image: apache/kafka
     ports:
       - '9092:9092'
+  mongodb:
+    image: mongo:latest
+    ports:
+      - '27017:27017'
+    environment:
+      - MONGO_INITDB_DATABASE=beep
+
 
 
 # CREATE A TOPIC

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,11 @@ use services::ServicesTrait;
 use tracing_subscriber;
 mod config;
 mod messaging;
+mod recorder;
 mod repositories;
 mod routes;
 mod server;
 mod services;
-mod recorder;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -18,9 +18,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let services =
         services::Services::build(&app_config.kafka_host, &app_config.mongodb_host).await?;
     let repos = repositories::Repositories::build(services);
-    let recorder = recorder::Recorder::build(repos.clone());
-    let routes = routes::create_route(repos);
-    let _ = recorder.start();
+    let routes = routes::create_route(repos.clone());
+    let recorder = recorder::Recorder::build(repos);
+    let _ = recorder.start().await;
     server::serve_app(app_config.http_host, app_config.http_port, routes).await?;
     Ok(())
 }

--- a/src/messaging/messages_controller.rs
+++ b/src/messaging/messages_controller.rs
@@ -21,5 +21,9 @@ pub async fn sse_handler(
     });
     let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(sse_event_stream).map(Ok);
 
-    Sse::new(stream)
+    Sse::new(stream).keep_alive(
+        axum::response::sse::KeepAlive::new()
+            .interval(std::time::Duration::from_secs(1))
+            .text("keep-alive-text")
+    )
 }

--- a/src/messaging/messages_service.rs
+++ b/src/messaging/messages_service.rs
@@ -8,23 +8,28 @@ pub async fn stream_kafka_events_rdkafka(
     state: Repositories,
     message_input: UnboundedSender<Event>,
 ) -> AbortHandle {
+    tracing::info!("Getting repo");
     let repo = state.messages_repo.read().await;
+    tracing::info!("Got repo");
     // Get the stream and map it to Events
     let (mut raw_stream, handle_streaming_end) = repo.get_topic_message_stream();
-
+    tracing::info!("Got stream");
     tokio::spawn(async move {
+        tracing::info!("Starting to stream messages sse");
         while let Some(message) = raw_stream.next().await {
+            tracing::info!("Received message");
             match message {
                 Ok(msg) => {
+                    tracing::info!("Sending message to SSE");
                     let _ = message_input.send(Event::default().data(msg));
                 }
                 Err(e) => {
-                    println!("Failed to receive message: {}", e);
+                    tracing::error!("Failed to receive message: {}", e);
                     return;
                 }
             }
         }
     });
-
+    
     handle_streaming_end
 }

--- a/src/repositories/messages_repo/model.rs
+++ b/src/repositories/messages_repo/model.rs
@@ -1,8 +1,10 @@
+use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Message {
-    pub _id: Option<String>,
+    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    pub id: Option<ObjectId>,
     pub content: String, 
 }
 

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -3,11 +3,7 @@ use std::sync::Arc;
 use messages_repo::MessagesRepoTrait;
 use tokio::sync::RwLock;
 
-use crate::services::{
-    kafka_client,
-    mongodb_client::{self, MongoDBClient},
-    Services,
-};
+use crate::services::Services;
 
 pub mod messages_repo;
 

--- a/src/services/kafka_client.rs
+++ b/src/services/kafka_client.rs
@@ -17,8 +17,7 @@ impl KafkaClientTrait for KafkaClient {
             .set("bootstrap.servers", host)
             .set("group.id", "my-group")
             .set("enable.partition.eof", "false")
-            .set("session.timeout.ms", "6000")
-            .set("enable.auto.commit", "true");
+            .set("session.timeout.ms", "6000");
 
         let producer: rdkafka::producer::FutureProducer =
             client.create().expect("Producer creation error");

--- a/src/services/mongodb_client.rs
+++ b/src/services/mongodb_client.rs
@@ -1,6 +1,10 @@
 use std::error::Error;
 
-use mongodb::{options::{ClientOptions, ServerApi, ServerApiVersion}, Client};
+use mongodb::{
+    bson::doc,
+    options::{ClientOptions, ServerApi, ServerApiVersion},
+    Client,
+};
 
 pub struct MongoDBClient {
     pub host: String,
@@ -12,11 +16,22 @@ pub trait MongoDBClientTrait: Send + Sync {
 }
 
 impl MongoDBClientTrait for MongoDBClient {
-    async fn build(host: &str) -> Result<MongoDBClient, Box<dyn Error>>  {
+    async fn build(host: &str) -> Result<MongoDBClient, Box<dyn Error>> {
         let mut client_options = ClientOptions::parse(host).await?;
         let server_api = ServerApi::builder().version(ServerApiVersion::V1).build();
         client_options.server_api = Some(server_api);
-        let client = Client::with_options(client_options)?;        
+        let client = Client::with_options(client_options)?;
+        match client
+            .database("beep")
+            .run_command(doc! { "ping": 1 })
+            .await
+        {
+            Ok(_) => tracing::info!("Connected to MongoDB"),
+            Err(e) => {
+                tracing::error!("Failed to connect to MongoDB: {}", e);
+                return Err(Box::new(e));
+            }
+        };
         Ok(MongoDBClient {
             host: host.to_string(),
             client,


### PR DESCRIPTION
When a message is sent by any client we want it is sent in  a kafka topic. Then a process that is constently listening to the topic will insert  the message in a collection and if a user is connected using sse he will receive all new messages.

Problem, both are working independently. But when i start the process to record the message in the mongo the sse socket is not able to get the messages anymore even if it is alive. 

The process start a new listener, no message are detected even if they are sent in the kafka topic. 
See [src/messages/messages_services.rs](https://github.com/hugoponthieu/poc-kafka-messaging/blob/feat/record-messages/src/messaging/messages_service.rs)